### PR TITLE
Ensure Drop runs on the whole original slice

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ Thread-local and thread-safe shared slice types, like `&[T]` but
 without lifetimes. This library depends only on `alloc` and `core`, so
 can be used in environments without `std`.
 """
+
+[dev-dependencies]
+
+rand = "0.3"

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -91,7 +91,7 @@ impl<T> ArcSlice<T> {
     /// Panics if `lo > hi` or if either are strictly greater than
     /// `self.len()`.
     pub fn slice(mut self, lo: usize, hi: usize) -> ArcSlice<T> {
-        self.data = unsafe {&(&*self.data)[lo..hi]};
+        self.data = &self[lo..hi];
         self
     }
     /// Construct a new `ArcSlice` that only points to elements at

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(unsafe_destructor)]
+#![feature(no_std)]
 #![cfg_attr(not(test), no_std)]
 
 //! Thread-local and thread-safe shared slice types, like `&[T]` but
@@ -18,9 +18,14 @@
 //! chunks and distribute them across some threads.
 //!
 //! ```rust
-//! # #![allow(unstable)]
+//! #![feature(std_misc)]
+//! extern crate shared_slice;
+//! extern crate rand;
+//!
 //! use shared_slice::arc::ArcSlice;
-//! use std::{cmp, rand, sync};
+//! use std::{cmp, sync};
+//!
+//! # fn main() {
 //!
 //! // Alice's numbers (the Mad Hatter doesn't care which numbers,
 //! // just that they've been summed up).
@@ -58,6 +63,8 @@
 //! let sum = futures.iter_mut().fold(0, |a, b| a + b.get());
 //!
 //! println!("the sum is {}", sum);
+//!
+//! # }
 //! ```
 //!
 //! (NB. `ArcSlice` may become unnecessary for situations like this if
@@ -66,7 +73,7 @@
 //! is likely that one will be able to use conventional borrowed
 //! `&[T]` slices directly.)
 
-#![feature(core, hash, alloc)]
+#![feature(core, alloc)]
 
 extern crate alloc;
 extern crate core;

--- a/src/rc.rs
+++ b/src/rc.rs
@@ -86,7 +86,7 @@ impl<T> RcSlice<T> {
     /// Panics if `lo > hi` or if either are strictly greater than
     /// `self.len()`.
     pub fn slice(mut self, lo: usize, hi: usize) -> RcSlice<T> {
-        self.data = unsafe {&(&*self.data)[lo..hi]};
+        self.data = &self[lo..hi];
         self
     }
     /// Construct a new `RcSlice` that only points to elements at


### PR DESCRIPTION
Fix the dropping issues by using `Rc<Box<T>>` and corresponding for `Arc`. This actually just decreases the complexity of the crate (no tricky destructor needed).

I also updated it to work on current rust nightly, of course. Notable is the loss of BorrowFrom/Borrow, which lives in libcollections.

Fixes #2
